### PR TITLE
Correct Moment.js string in "Format Time" transformation

### DIFF
--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -244,14 +244,6 @@
               }
             ]
           }
-        },
-        {
-          "id": "formatTime",
-          "options": {
-            "outputFormat": "DD/MM/YYYY HH:MM:SS",
-            "timeField": "Time",
-            "useTimezone": true
-          }
         }
       ],
       "type": "table"
@@ -264,9 +256,10 @@
     "list": [
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "Machine_Name_Here",
-          "value": "Machine_Name_Here"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -297,6 +290,6 @@
   "timezone": "browser",
   "title": "Count Events",
   "uid": "ddz2cmqkykg00a",
-  "version": 5,
+  "version": 2,
   "weekStart": ""
 }

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -248,7 +248,7 @@
         {
           "id": "formatTime",
           "options": {
-            "outputFormat": "DD/MM/YYYY HH:mm:ss",
+            "outputFormat": "HH:mm:ss DD/MM/YYYY",
             "timeField": "Time",
             "useTimezone": true
           }

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -244,6 +244,14 @@
               }
             ]
           }
+        },
+        {
+          "id": "formatTime",
+          "options": {
+            "outputFormat": "DD/MM/YYYY HH:mm:ss",
+            "timeField": "Time",
+            "useTimezone": true
+          }
         }
       ],
       "type": "table"


### PR DESCRIPTION
Fixes #4 
Error in timestamp format spec that confused months with minutes, and seconds with fractional seconds etc.

Also deselected the default machine. 