### PR TITLE
Bugfix/hardcoded machine name in transforms

### DIFF
--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -82,7 +82,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"shoestring_data_bucket\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"count_monitoring\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"event\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")",
+          "query": "from(bucket: \"shoestring_data_bucket\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"count_monitoring\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"event\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n  |> keep(columns: [\"_time\", \"_field\", \"_value\"])",
           "refId": "A"
         }
       ],
@@ -257,10 +257,9 @@
     "list": [
       {
         "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
+          "selected": true,
+          "text": "My_Machine_Name_Here",
+          "value": "My_Machine_Name_Here"
         },
         "datasource": {
           "type": "influxdb",
@@ -291,6 +290,6 @@
   "timezone": "browser",
   "title": "Count Events",
   "uid": "ddz2cmqkykg00a",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -257,9 +257,10 @@
     "list": [
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "My_Machine_Name_Here",
-          "value": "My_Machine_Name_Here"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -257,9 +257,10 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "My_Machine_Name_Here",
-          "value": "My_Machine_Name_Here"
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -98,18 +98,7 @@
                 ],
                 "operation": "aggregate"
               },
-              "buttons_pressed": {
-                "aggregations": []
-              },
-              "buttons_pressed MachineNameHere": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
               "event": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "event Machine_Name_Here": {
                 "aggregations": [],
                 "operation": "groupby"
               }
@@ -291,6 +280,6 @@
   "timezone": "browser",
   "title": "Count Events",
   "uid": "ddz2cmqkykg00a",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -203,7 +203,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"shoestring_data_bucket\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"count_monitoring\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")",
+          "query": "from(bucket: \"shoestring_data_bucket\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"count_monitoring\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n  |> keep(columns: [\"_time\", \"_field\", \"_value\"])",
           "refId": "A"
         }
       ],
@@ -216,20 +216,13 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": {
-              "buttons_pressed Machine_Name_Here": false
-            },
+            "excludeByName": {},
             "includeByName": {},
-            "indexByName": {
-              "Time": 1,
-              "buttons_pressed MachineNameHere": 0
-            },
+            "indexByName": {},
             "renameByName": {
-              "Time": "",
-              "buttons_pressed Breadboard": "Buttons Pressed",
-              "buttons_pressed MachineNameHere": "Buttons Pressed",
-              "buttons_pressed {machine=\"Machine_Name_Here\", name=\"count_monitoring\"}": "Sensors triggered",
-              "event {machine=\"Machine_Name_Here\", name=\"count_monitoring\"}": "Event description"
+              "Time": "Time",
+              "buttons_pressed": "Sensors Triggered",
+              "event": "Event Description"
             }
           }
         },
@@ -264,10 +257,9 @@
     "list": [
       {
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "My_Machine_Name_Here",
+          "value": "My_Machine_Name_Here"
         },
         "datasource": {
           "type": "influxdb",


### PR DESCRIPTION
Fixes #3 
Drops the machine name (and anything else unneeded) from the query results. Simplifies the transforms. Transforms now work for all machines.