### PR TITLE
Feature/dash totals stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Uses the [Sequent Microsystems 16 input HAT](https://sequentmicrosystems.com/pro
 ### Usage
 - View the dashboard: navigate to `localhost:3000` in a web browser
 
-![image](https://github.com/user-attachments/assets/73dce43c-f8e3-4503-980e-b74e95d23392)
+![image](https://github.com/user-attachments/assets/1f913230-983d-4f8b-be5d-6938141ba683)

--- a/UserConfig/Grafana/dashboards/countevents.json
+++ b/UserConfig/Grafana/dashboards/countevents.json
@@ -86,7 +86,7 @@
           "refId": "A"
         }
       ],
-      "title": "Event Counts at ${machine}",
+      "title": "Event Counts by Description",
       "transformations": [
         {
           "id": "groupBy",
@@ -166,7 +166,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 13,
+        "h": 21,
         "w": 12,
         "x": 12,
         "y": 0
@@ -176,7 +176,7 @@
         "cellHeight": "sm",
         "footer": {
           "countRows": false,
-          "enablePagination": false,
+          "enablePagination": true,
           "fields": "",
           "reducer": [
             "sum"
@@ -196,7 +196,7 @@
           "refId": "A"
         }
       ],
-      "title": "Events at ${machine}",
+      "title": "Events Log",
       "transformations": [
         {
           "id": "joinByField",
@@ -237,6 +237,132 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "No data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 13
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "distinctCount"
+          ],
+          "fields": "/^event$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb"
+          },
+          "query": "from(bucket: \"shoestring_data_bucket\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"count_monitoring\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"event\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n  |> keep(columns: [\"_time\", \"_field\", \"_value\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Distinct Events",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "No data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 13
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "count"
+          ],
+          "fields": "/^event$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb"
+          },
+          "query": "from(bucket: \"shoestring_data_bucket\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"count_monitoring\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"event\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n  |> keep(columns: [\"_time\", \"_field\", \"_value\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Events",
+      "type": "stat"
     }
   ],
   "refresh": "5s",
@@ -280,6 +406,6 @@
   "timezone": "browser",
   "title": "Count Events",
   "uid": "ddz2cmqkykg00a",
-  "version": 4,
+  "version": 9,
   "weekStart": ""
 }


### PR DESCRIPTION
Feature: dashboard facelift

Added big stat for total event count at selected machine.
Added big stat for distinct event descriptions at selected machine.
Extended Events log table to fit screen height and allowed pagination.
Removed `at ${machine}` from each panel title (now having the name 5 times on the screen was a bit much).

i.e. From this
![image](https://github.com/user-attachments/assets/73dce43c-f8e3-4503-980e-b74e95d23392)

To this
![image](https://github.com/user-attachments/assets/1f913230-983d-4f8b-be5d-6938141ba683)